### PR TITLE
update build_scope

### DIFF
--- a/lib/store_base_sti_class_for_4_2.rb
+++ b/lib/store_base_sti_class_for_4_2.rb
@@ -49,21 +49,21 @@ if ActiveRecord::VERSION::STRING =~ /^4\.2/
             scope = klass.unscoped
 
             values         = reflection_scope.values
+            reflection_binds = reflection_scope.bind_values
             preload_values = preload_scope.values
+            preload_binds  = preload_scope.bind_values
 
             scope.where_values      = Array(values[:where])      + Array(preload_values[:where])
             scope.references_values = Array(values[:references]) + Array(preload_values[:references])
+            scope.bind_values       = (reflection_binds + preload_binds)
 
-            select_method = scope.respond_to?(:select!) ? :select! : :_select!
-            scope.send select_method, preload_values[:select] || values[:select] || table[Arel.star]
+            scope._select!   preload_values[:select] || values[:select] || table[Arel.star]
             scope.includes! preload_values[:includes] || values[:includes]
+            scope.joins! preload_values[:joins] || values[:joins]
+            scope.order! preload_values[:order] || values[:order]
 
-            if preload_values.key? :order
-              scope.order! preload_values[:order]
-            else
-              if values.key? :order
-                scope.order! values[:order]
-              end
+            if preload_values[:readonly] || values[:readonly]
+              scope.readonly!
             end
 
             if options[:as]


### PR DESCRIPTION
Updates build_scope thus fixes following
DEPRECATION WARNING: Modifying already cached Relation. The cache will be reset. Use a cloned Relation to prevent this warning. (called from build_scope at .../gems/store_base_sti_class-aa6be44e4f44/lib/store_base_sti_class_for_4_2.rb:58
